### PR TITLE
Support max-age Cache-Control HTTP header

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ var cacheEx=require('cache-ex')({secret:'dont tell a soul'});
 secret,timeToLive
 - `timeToLive`: the standard ttl as number in seconds for every generated cache element. Default = 0 = unlimited
 - `secret`: A secret word to protect flusing of the cache
-
+= `cacheControlMaxAge`: HTTP Cache-Control header will be sent with this max-age if set and > 0 when serving content from the cache.
 
 ## Retrieve and Serve cached data:
 
@@ -36,6 +36,13 @@ app.get('/any',function(req,res){
 	cacheEx.put({object:'Cached Object',req:req.query},req);
 	res.send({status:'Not from cache',req:req.query});
 });
+
+Or add and send in one fn call. This ensures any cache control headers configured are sent the same from first and subsequent calls.
+
+app.get('/any',function(req,res){
+	cacheEx.putAndServe({object:'Cached Object',req:req.query},req, res);
+});
+
 ```
 `cache-ex` does not cache POST requests only GET.
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,10 +6,27 @@ function CEX(options){
 	if (!options.secret) throw new Error('No secret supplied for cache admin');
 	this.cache= new NodeCache();
 	this.secret=options.secret;
-	this.aTimeToLive=aTimeToLive=options.timeToLive || 0;
-	this.put=function(data,req){
-		this.cache.set(getKey(req),data,this.aTimeToLive);
+	this.aTimeToLive=options.timeToLive || 0;
+	this.maxAge=options.cacheControlMaxAge || 0;
+};
+
+CEX.prototype.put = function(data,req){
+	this.cache.set(getKey(req),data,this.aTimeToLive);
+};
+
+CEX.prototype.putAndServe = function(data,req,res){
+	this.put(data,req);
+	this.send(data,res);
+};
+
+CEX.prototype.send = function(data, res){
+	if(!res.get('Content-Type')){
+		res.header('Content-Type','application/json');
 	}
+	if(this.maxAge > 0 ){
+		res.header('Cache-Control', 'public, max-age=' + this.maxAge);
+	}
+	return res.send(data);
 };
 
 CEX.prototype.serve = function(){
@@ -22,15 +39,13 @@ CEX.prototype.serve = function(){
 		self.cache.get(key,function(err,value){
 			if(!isEmpty(value)){
 				res.locals.data=value[key];
-				if(!res.get('Content-Type')){
-					res.header('Content-Type','application/json');
-				}
-				return res.send(res.locals.data);
+				return self.send(res.locals.data, res);
 			}
 			next();
 		});
 	}
-}
+};
+
 CEX.prototype.admin=function(){
 	var self=this;
 	return function(req,res,next){

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cache-ex",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "Cache-ex",
   "keywords": [
     "cache",


### PR DESCRIPTION
allow a configures max-age Cache-Control header to be set when serving
data from the cache.

Adding a putAndServe fn so the same headers are added when data it first
served also.